### PR TITLE
Removed appveyor Nuget cache

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -4,7 +4,6 @@ build_script:
 - ps: .\build.ps1
 cache:
   - tools\Cake -> tools\packages.config # Cake NuGet cache
-  - '%USERPROFILE%\.nuget\packages -> **\*.csproj'  # NuGet Cache
   - src\Frontend\node_modules -> src\Frontend\package.json
   - src\React_Admin\node_modules -> src\React_Admin\package.json
 test: off


### PR DESCRIPTION
This is due to the fact that restore time of cache takes a long time, however restoring of the packages does not take a long time